### PR TITLE
Add architecture doc and module placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ GlukoLab ima za cilj da bude jednostavan, pouzdan alat koji korisnicima pomaže 
 ## Napomena
 
 Aplikacija nije medicinski proizvod. Namenjena je isključivo za lično informisanje korisnika. Za sve odluke vezane za zdravlje, konsultujte se sa lekarom.
+
+---
+
+## Architecture Overview
+
+For details on the recommended project structure and technology stack, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,1 @@
+# Placeholder for app module

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,1 @@
+# Placeholder for core module

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,1 @@
+# Placeholder for data module

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,45 @@
+# GlukoLab Architecture Proposal
+
+This document outlines a possible architecture for the GlukoLab Android application. The goal is to keep the codebase modular and easy to maintain while supporting a modern, minimalist user experience.
+
+## Technology stack
+
+- **Programming language**: Kotlin
+- **UI framework**: [Jetpack Compose](https://developer.android.com/jetpack/compose)
+- **Dependency injection**: [Hilt](https://developer.android.com/training/dependency-injection/hilt-android)
+- **Asynchronous programming**: Kotlin Coroutines & Flow
+- **Data storage**: Room database for local storage, with optional cloud sync in the future
+- **Architecture pattern**: Clean Architecture with MVVM for the presentation layer
+
+## Module structure
+
+```
+GlukoLab/
+│
+├── app/             # Main Android application module
+├── core/            # Reusable utilities and base classes
+├── data/            # Repositories and data sources (BLE, database, etc.)
+├── domain/          # Business logic and use cases
+└── presentation/    # Compose screens and view models
+```
+
+*Modules can be added gradually as the project evolves.*
+
+## BLE communication
+
+BLE communication with the Libre 2 sensor should be isolated in the `data` module. Use a repository pattern to expose sensor data as Kotlin `Flow` streams. This allows the rest of the app to remain agnostic of the BLE implementation.
+
+## UI layer
+
+Jetpack Compose enables a clean, declarative approach to building UI. Combine Compose with ViewModels from the `presentation` module to reactively update screens as data changes. Keep UI minimal and focused on current glucose values and trend charts.
+
+## Testing
+
+- Use JUnit and AndroidX Test for unit and instrumentation tests
+- Prefer testable components in the `domain` and `data` modules
+- Mock BLE and database layers during tests
+
+## Future extensions
+
+The architecture should allow future features such as A/B testing of meals, analytics, and cloud synchronization. By separating the app into clear modules and using dependency injection, new functionality can be added with minimal impact on existing code.
+

--- a/domain/README.md
+++ b/domain/README.md
@@ -1,0 +1,1 @@
+# Placeholder for domain module

--- a/presentation/README.md
+++ b/presentation/README.md
@@ -1,0 +1,1 @@
+# Placeholder for presentation module


### PR DESCRIPTION
## Summary
- document recommended architecture in `docs/ARCHITECTURE.md`
- link to architecture doc from README
- add placeholder directories for planned modules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68753938954c832692d6160a241c8f62